### PR TITLE
libldb fixes for newer kernels and race condition

### DIFF
--- a/libldb/Makefile
+++ b/libldb/Makefile
@@ -12,7 +12,7 @@ libldb.a: hook.o logger.o monitor.o event.o tag.o
 	$(AR) qc $@ $^
 
 libshim.so: shim.o event.o
-	$(CC) -shared -lpthread -ldl -o $@ $^
+	$(CC) -shared -lpthread -ldl -rdynamic -o $@ $^
 
 shim.o: shim.c
 	$(CC) -O1 -g -fdebug-default-version=3 -fno-omit-frame-pointer -fPIC -o $@ -c $<

--- a/libldb/common.h
+++ b/libldb/common.h
@@ -10,6 +10,8 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 
+#include "lock.h"
+
 #define CYCLES_PER_US 2396
 #define SHM_KEY 401916
 #define LDB_MAX_NTHREAD 128
@@ -45,7 +47,7 @@ enum ldb_event_type {
 };
 
 typedef struct {
-  int event_type; 
+  int event_type;
   uint32_t sec;
   uint32_t nsec;
   uint32_t tid;
@@ -71,8 +73,8 @@ typedef struct {
   struct timespec ts_wait;
   struct timespec ts_lock;
   struct timespec ts_scan;
+  ldb_thread_info_lock_t lock;
 } ldb_thread_info_t;
-
 typedef struct {
   ldb_thread_info_t *ldb_thread_infos;
   int ldb_nthread;

--- a/libldb/lock.h
+++ b/libldb/lock.h
@@ -1,0 +1,76 @@
+/*
+    A simple spin lock to prevent race condition on accessing
+    and cleaning up the thread_info regions.
+    
+    This spinlock does not require (de-)initialization, where
+    a value of 0 just means it can be aquired. And can also be
+    implicitly unlocked when zeroing out the ldb_thread_info_t
+*/
+
+#ifndef LDB_LOCK_H
+#define LDB_LOCK_H
+
+#include <stdatomic.h>
+#include <stdbool.h>
+
+typedef struct {
+    atomic_int counter; // positive: number of readers, -1: writer holds the lock
+} ldb_thread_info_lock_t;
+
+// try to acquire read lock (non-blocking)
+inline __attribute__((always_inline)) bool ldb_thread_info_lock_try_acquire_read(ldb_thread_info_lock_t *lock) {
+    int count = atomic_load_explicit(&lock->counter, memory_order_acquire);
+    if (count < 0) {
+        // writer holds the lock; cannot acquire read lock
+        return false;
+    }
+    // attempt to increment the reader count
+    if (atomic_compare_exchange_strong_explicit(
+            &lock->counter, &count, count + 1,
+            memory_order_acquire, memory_order_relaxed)) {
+        // acquired read lock
+        return true;
+    }
+    // failed to acquire read lock
+    return false;
+}
+
+// acquire read lock (blocking)
+inline __attribute__((always_inline)) void ldb_thread_info_lock_acquire_read(ldb_thread_info_lock_t *lock) {
+    while (true) {
+        int count = atomic_load_explicit(&lock->counter, memory_order_acquire);
+        if (count < 0) {
+            // writer holds lock, keep spinning
+            continue;
+        }
+        if (atomic_compare_exchange_weak_explicit(
+                &lock->counter, &count, count + 1,
+                memory_order_acquire, memory_order_relaxed)) {
+            // successfully acquired read lock
+            return;
+        }
+    }
+}
+
+// release read lock
+inline __attribute__((always_inline)) void ldb_thread_info_lock_release_read(ldb_thread_info_lock_t *lock) {
+    atomic_fetch_sub_explicit(&lock->counter, 1, memory_order_release);
+}
+
+// acquire write lock (blocking)
+inline __attribute__((always_inline)) void ldb_thread_info_lock_acquire_write(ldb_thread_info_lock_t *lock) {
+    int expected;
+    do {
+        expected = 0;
+        // attempt to set counter from 0 to -1
+    } while (!atomic_compare_exchange_strong_explicit(
+                &lock->counter, &expected, -1,
+                memory_order_acquire, memory_order_relaxed));
+}
+
+// release write lock
+inline __attribute__((always_inline)) void ldb_thread_info_lock_release_write(ldb_thread_info_lock_t *lock) {
+    atomic_store_explicit(&lock->counter, 0, memory_order_release);
+}
+
+#endif // LDB_LOCK_H

--- a/libldb/monitor.c
+++ b/libldb/monitor.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <time.h>
 #include "common.h"
+#include "lock.h"
 
 #define LDB_MONITOR_PERIOD 0
 
@@ -40,7 +41,7 @@ struct thread {
   int cnt;
   uint64_t last_gen;
   uint64_t *stack_base;
-  struct timespec last_ts; 
+  struct timespec last_ts;
   struct tls_shared_region *tls;
   struct stack_sample samples[LDB_MAX_CALLDEPTH];
 };
@@ -50,20 +51,37 @@ static int scan_stack(struct thread *th, uint64_t *rbp, struct stack_sample *sar
   int frames = 0;
 
   // Heuristic: If start rbp is not valid, skip this iteration
-  if (rbp <= (uint64_t *)0x7f0000000000 || rbp > th->stack_base)
+  /*
+    BUG FIX Oct 10 by Coulson:
+    Removed the heuristic of comparing stack_base with the kernel's stack address boundary,
+    because that particular boundary changes in newer kernel versions.
+  */
+  if (rbp > th->stack_base) {
+    // printf("scan_stack: Invalid starting RBP %p for thread %d, unwind start rbp: %p\n", rbp, th->thread_id, th->stack_base);
     return -1;
+  }
 
-  while (rbp) {
-    // check for invalid base pointers
-    if (rbp <= top || rbp > th->stack_base) {
-      return -1; 
+  while (true) {
+    // Check if we've reached the initial RBP
+    if (rbp == th->stack_base) {
+      // printf("scan_stack: Reached initial RBP %p for thread %d\n", rbp, th->thread_id);
+      break; // Reached the base of the stack
+    }
+
+    // Check for invalid base pointers
+    if (rbp <= top || rbp > th->stack_base || rbp == NULL) {
+      // printf("scan_stack: Invalid RBP %p encountered for thread %d\n", rbp, th->thread_id);
+      return -1;
     }
 
     uint64_t canary_and_tag = *(rbp + 1);
     uint32_t canary = (uint32_t)(canary_and_tag >> 32);
     if (canary != LDB_CANARY) {
+      // printf("scan_stack: Canary mismatch at RBP %p for thread %d, expected %x, found %x\n",
+      //        rbp, th->thread_id, LDB_CANARY, canary);
       return -1;
     }
+
     sarr->gen = *(rbp + 2);
     sarr->rip = *(rbp + 3);
     sarr->rbp = (uint64_t)rbp;
@@ -71,7 +89,7 @@ static int scan_stack(struct thread *th, uint64_t *rbp, struct stack_sample *sar
     frames++;
 
     if (frames > LDB_MAX_CALLDEPTH) {
-      printf("[WARNING] max call depth exceeded\n");
+      printf("[WARNING] max call depth exceeded for thread %d\n", th->thread_id);
       return -1;
     }
 
@@ -112,6 +130,7 @@ static void scan_thread(struct thread *th) {
   // Skip if a modification wasn't detected (to avoid probe effects)
   uint64_t gen = ACCESS_ONCE(th->tls->gen);
   uint64_t rbp = ACCESS_ONCE(th->tls->rbp);
+
   if (gen == th->last_gen) {
     return;
   }
@@ -121,9 +140,12 @@ static void scan_thread(struct thread *th) {
 
   // Scan the stack and gather frames 
   frames = scan_stack(th, (uint64_t *)rbp, tmp);
+
   uint64_t end_gen = ACCESS_ONCE(th->tls->gen);
   uint64_t end_rbp = ACCESS_ONCE(th->tls->rbp);
+
   if (frames < 0 || end_gen != gen || end_rbp != rbp) {
+    // printf("scan_thread: Stack scan failed or inconsistent gen-num for thread %d\n", th->thread_id);
     if (!th->last_ts_set) {
       th->last_ts_set = true;
       th->last_ts = now;
@@ -140,8 +162,6 @@ static void scan_thread(struct thread *th) {
 
   // Store frames (in reverse so top is first) for next comparison
   for (i = 0; i < frames; i++) {
-    //printf("i %d rbp %lx rip %lx\n", i, th->samples[i].rbp, th->samples[i].rip); 
-    //printf("i %d rbp %lx rip %lx\n", i, tmp[frames - i - 1].rbp, tmp[frames - i - 1].rip);
     th->samples[i].rip = tmp[frames - i - 1].rip;
     th->samples[i].rbp = tmp[frames - i - 1].rbp;
 
@@ -183,17 +203,41 @@ void *monitor_main(void *arg) {
 #endif
     for (i = 0; i < LDB_MAX_NTHREAD; i++) {
       struct thread *th = &threads[i];
-      if (ldb_shared->ldb_thread_infos[i].id == 0)
+      /*
+        BUF FIX Oct 24 by Coulson:
+        Previously the monitor has a TOCTTOU race condition,
+        where the thread_info-> id is non-zero when checked,
+        but the TLS of the scanned thread is already freed as
+        the thread terminated.
+
+        So I use a simple spin lock, which doesn't block
+        the monitor/logger's, but prevent the user
+        program's thread to exit during scanning/logging.
+      */
+
+      ldb_thread_info_t *thread_info = &ldb_shared->ldb_thread_infos[i];
+
+      if (!ldb_thread_info_lock_try_acquire_read(&thread_info->lock)) {
         continue;
+      }
+
+      pid_t id = thread_info->id;
+      if (id == 0) {
+        ldb_thread_info_lock_release_read(&thread_info->lock);
+        continue;
+      }
+      atomic_thread_fence(memory_order_acquire);
 
       // initialize per-thread state
-      th->thread_id = ldb_shared->ldb_thread_infos[i].id;
-      uint64_t *tmp = (uint64_t *)ldb_shared->ldb_thread_infos[i].fsbase;
+      th->thread_id = id;
+      uint64_t *tmp = (uint64_t *)thread_info->fsbase;
       th->tls = (struct tls_shared_region *)(tmp - 43);
-      th->stack_base = (uint64_t *)ldb_shared->ldb_thread_infos[i].stackbase;
+      th->stack_base = (uint64_t *)thread_info->stackbase;
 
       // scan the thread's stack
       scan_thread(th);
+
+      ldb_thread_info_lock_release_read(&thread_info->lock);
     }
 #if LDB_MONITOR_PERIOD > 0
     clock_get_now(&scan_finish);

--- a/libldb/shim.c
+++ b/libldb/shim.c
@@ -12,10 +12,11 @@
 #include <dlfcn.h>
 
 #include "common.h"
+#include "lock.h"
 
 ldb_shmseg *ldb_shared;
 
-typedef struct {   
+typedef struct {
   void *(*worker_func)(void *param);
   void *param;
 } pthread_param_t;
@@ -47,7 +48,8 @@ static inline int get_tidx() {
 }
 
 static inline void put_tidx(int tidx) {
-  memset(&ldb_shared->ldb_thread_infos[tidx], 0, sizeof(ldb_thread_info_t));
+  // here we also implicitly unlocked the ldb_thread_info_lock_t
+  memset(&ldb_shared->ldb_thread_infos[tidx], 0, sizeof(ldb_thread_info_t) - sizeof(ldb_thread_info_lock_t));
 
   // This is the last slot
   if (tidx == ldb_shared->ldb_max_idx - 1) {
@@ -91,29 +93,46 @@ void *__ldb_thread_start(void *arg) {
   pthread_param_t real_thread_params;
 
   memcpy(&real_thread_params, arg, sizeof(pthread_param_t));
-
   free(arg);
+
+  /*
+    BUG FIX Oct 10, 2024 by Coulson:
+    Previously we set base rbp to 0 as a stopping sign for stack unwinding,
+    but for Ubuntu 24.04 and newer glibc, this particular operation breaks
+    some thread cleanup code, causing corruptions.
+    So switched to using the stack_base address as the end of unwinding,
+    and reordered some operations.
+  */
 
   // initialize canary
   setup_canary();
-
-  // initialize stack
-  char *rbp = get_fs_rbp(); // this is the rbp of thread main
-
-  // set ngen to 0
-  *((uint64_t *)(rbp + 16)) = 0;
-  // set canary and tag
-  *((uint64_t *)(rbp + 8)) = (uint64_t)LDB_CANARY << 32;
-  // set old RBP
-  *((uint64_t *)rbp) = 0;
-
-  printf("New interposed thread is starting... thread ID = %ld\n", syscall(SYS_gettid));
-  printf("ngen = %lu, tls rbp = %p, real rbp = %p, tls = %p - %p\n", get_ngen(), get_fs_rbp(), get_rbp(), (void *)(rdfsbase()-200), (void *)rdfsbase());
 
   // attach shared memory
   if (unlikely(!ldb_shared)) {
     ldb_shared = attach_shared_memory();
   }
+
+  // initialize stack
+  char *rbp = get_fs_rbp(); // this is the rbp of thread main
+
+  // Set ngen to 0
+  *((uint64_t *)(rbp + 16)) = 0;
+  // Set canary and tag
+  *((uint64_t *)(rbp + 8)) = (uint64_t)LDB_CANARY << 32;
+
+  Dl_info info;
+  if (dladdr(real_thread_params.worker_func, &info) && info.dli_sname) {
+    printf("New interposed thread is starting... thread ID = %ld, function = %s\n",
+           syscall(SYS_gettid), info.dli_sname);
+  } else {
+    // if we failed to resolve the function name, just print its address
+    // -rdynamic should be used to compile the program!
+    printf("New interposed thread is starting... thread ID = %ld, function = %p\n",
+           syscall(SYS_gettid), real_thread_params.worker_func);
+  }
+
+  printf("ngen = %lu, tls rbp = %p, real rbp = %p, tls = %p - %p\n",
+    get_ngen(), get_fs_rbp(), get_rbp(), (void *)(rdfsbase()-200), (void *)rdfsbase());
 
   // allocate & initialize event buffer
   ldb_event_buffer_t *ebuf = (ldb_event_buffer_t *)malloc(sizeof(ldb_event_buffer_t));
@@ -126,14 +145,22 @@ void *__ldb_thread_start(void *arg) {
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 
-  // start tracking
+  // start tracking (populate thread info)
   pthread_spin_lock(&(ldb_shared->ldb_tlock));
   tidx = get_tidx();
   pid_t id = syscall(SYS_gettid);
-  ldb_shared->ldb_thread_infos[tidx].id = id;
+
+  // Populate other metadata
   ldb_shared->ldb_thread_infos[tidx].fsbase = (char **)(rdfsbase());
   ldb_shared->ldb_thread_infos[tidx].stackbase = rbp;
   ldb_shared->ldb_thread_infos[tidx].ebuf = ebuf;
+
+  // ensure memory ordering of before setting 'id'
+  atomic_thread_fence(memory_order_release);
+
+  // Set 'id' to indicate the thread is ready
+  ldb_shared->ldb_thread_infos[tidx].id = id;
+
   pthread_spin_unlock(&(ldb_shared->ldb_tlock));
 
   ldb_shared->ldb_thread_infos[tidx].ts_wait = now;
@@ -146,7 +173,7 @@ void *__ldb_thread_start(void *arg) {
   event_record(ebuf, LDB_EVENT_THREAD_CREATE, now, id,
                (uintptr_t)real_thread_params.worker_func, 0, 0);
 
-  // execute real thread
+  // finally, execute the real thread function
   ret = real_thread_params.worker_func(real_thread_params.param);
 
   // record an event for the exiting of the thread
@@ -155,10 +182,13 @@ void *__ldb_thread_start(void *arg) {
 
   // stop tracking
   pthread_spin_lock(&(ldb_shared->ldb_tlock));
-  put_tidx(tidx);
+  // acquire the write lock before clearing 'id' and other metadata
+  ldb_thread_info_lock_acquire_write(&ldb_shared->ldb_thread_infos[tidx].lock);
+  put_tidx(tidx); // setting the thread's id and other metadata to 0 in shm
+  ldb_thread_info_lock_release_write(&ldb_shared->ldb_thread_infos[tidx].lock);
   pthread_spin_unlock(&(ldb_shared->ldb_tlock));
 
-  printf("Application thread is exitting... %lu data point ignored\n", ebuf->nignored);
+  printf("Application thread is exiting... %lu data point ignored\n", ebuf->nignored);
 
   free(ebuf->events);
   free(ebuf);
@@ -428,7 +458,7 @@ void free(void *ptr) {
     }
   }
 
-  return real_free(ptr); 
+  return real_free(ptr);
 }
 
 /* other useful functions */


### PR DESCRIPTION
Hi, Inho, lately has been trying out LDB on more programs and new environments.

This PR for the libldb mainly fixes 2 issues:
- In newer kernel/glibc version, setting the user spawned thread's base RPP to 0 breaks the pthread library
- Previously, the monitor, logger, and shim layer's pthread_create have TOCTTOU race condition on the thread_info in the shared memory, and the monitor segfaults when accessing the TLS of a thread that already exits.

The specific modification explanations are in the "BUF FIX" comments. I'm still using LDB actively and thus testing these changes more, so you don't need to merge this PR at all. I just thought maybe you can give some suggestions or perceive something wrong in these changes. Thank you!